### PR TITLE
Minor documentation fixes

### DIFF
--- a/slixmpp/clientxmpp.py
+++ b/slixmpp/clientxmpp.py
@@ -141,8 +141,11 @@ class ClientXMPP(BaseXMPP):
         will be used.
 
         :param address: A tuple containing the server's host and port.
-        :param use_tls: Indicates if TLS should be used for the
-                        connection. Defaults to ``True``.
+        :param force_starttls: Indicates that negotiation should be aborted
+                               if the server does not advertise support for
+                               STARTTLS. Defaults to ``True``.
+        :param disable_starttls: Disables TLS for the connection.
+                                 Defaults to ``False``.
         :param use_ssl: Indicates if the older SSL connection method
                         should be used. Defaults to ``False``.
         """

--- a/slixmpp/xmlstream/xmlstream.py
+++ b/slixmpp/xmlstream/xmlstream.py
@@ -256,9 +256,9 @@ class XMLStream(asyncio.BaseProtocol):
         TODO fix the comment
         :param force_starttls: If True, the connection will be aborted if
                                the server does not initiate a STARTTLS
-                               negociation.  If None, the connection will be
+                               negotiation.  If None, the connection will be
                                upgraded to TLS only if the server initiate
-                               the STARTTLS negociation, otherwise it will
+                               the STARTTLS negotiation, otherwise it will
                                connect in clear.  If False it will never
                                upgrade to TLS, even if the server provides
                                it.  Use this for example if you’re on


### PR DESCRIPTION
Fix a typo and tweak docstring to fix a kwarg that doesn't exist.
