### PR TITLE
Fix fetching the SSL socket for Python 3.4 and 3.5

### DIFF
--- a/slixmpp/xmlstream/xmlstream.py
+++ b/slixmpp/xmlstream/xmlstream.py
@@ -506,7 +506,9 @@ class XMLStream(asyncio.BaseProtocol):
                 else:
                     self.event('ssl_invalid_chain', e)
             else:
-                der_cert = transp.get_extra_info("socket").getpeercert(True)
+                # Workaround for a regression in 3.4 where ssl_object was not set.
+                der_cert = transp.get_extra_info("ssl_object",
+                                                 default=transp.get_extra_info("socket")).getpeercert(True)
                 pem_cert = ssl.DER_cert_to_PEM_cert(der_cert)
                 self.event('ssl_cert', pem_cert)
 


### PR DESCRIPTION
Ensure we get the SSL socket after STARTTLS in both Python 3.4 (where a regression prevented ssl_object from being set) and in 3.5.
