### PR TITLE
Move SSLContext to own function, also pass it to plain TLS connections

### DIFF
--- a/slixmpp/xmlstream/xmlstream.py
+++ b/slixmpp/xmlstream/xmlstream.py
@@ -487,14 +487,10 @@ class XMLStream(asyncio.BaseProtocol):
         """
         pass
 
-    def start_tls(self):
-        """Perform handshakes for TLS.
-
-        If the handshake is successful, the XML stream will need
-        to be restarted.
+    def get_ssl_context(self):
         """
-        self.event_when_connected = "tls_success"
-
+        Get SSL context.
+        """
         if self.ciphers is not None:
             self.ssl_context.set_ciphers(self.ciphers)
         if self.keyfile and self.certfile:
@@ -509,7 +505,18 @@ class XMLStream(asyncio.BaseProtocol):
             self.ssl_context.verify_mode = ssl.CERT_REQUIRED
             self.ssl_context.load_verify_locations(cafile=self.ca_certs)
 
-        ssl_connect_routine = self.loop.create_connection(lambda: self, ssl=self.ssl_context,
+        return self.ssl_context
+
+    def start_tls(self):
+        """Perform handshakes for TLS.
+
+        If the handshake is successful, the XML stream will need
+        to be restarted.
+        """
+        self.event_when_connected = "tls_success"
+
+        ssl_context = self.get_ssl_context()
+        ssl_connect_routine = self.loop.create_connection(lambda: self, ssl=ssl_context,
                                                           sock=self.socket,
                                                           server_hostname=self.default_domain)
         @asyncio.coroutine

--- a/slixmpp/xmlstream/xmlstream.py
+++ b/slixmpp/xmlstream/xmlstream.py
@@ -297,12 +297,15 @@ class XMLStream(asyncio.BaseProtocol):
             # and try (host, port) as a last resort
             self.dns_answers = None
 
+        if self.use_ssl:
+            ssl_context = self.get_ssl_context()
+
         yield from asyncio.sleep(self.connect_loop_wait)
         try:
             yield from self.loop.create_connection(lambda: self,
                                                    self.address[0],
                                                    self.address[1],
-                                                   ssl=self.use_ssl,
+                                                   ssl=ssl_context,
                                                    server_hostname=self.default_domain if self.use_ssl else None)
         except Socket.gaierror as e:
             self.event('connection_failed',

--- a/slixmpp/xmlstream/xmlstream.py
+++ b/slixmpp/xmlstream/xmlstream.py
@@ -299,6 +299,8 @@ class XMLStream(asyncio.BaseProtocol):
 
         if self.use_ssl:
             ssl_context = self.get_ssl_context()
+        else:
+            ssl_context = False
 
         yield from asyncio.sleep(self.connect_loop_wait)
         try:


### PR DESCRIPTION
This pull request moves getting the SSL context used for STARTLS into its own function. It also passes the context to plain TLS connections (now becoming more important again due to [XEP-0368](https://xmpp.org/extensions/xep-0368.html) instead of just passing True/False.

The motivation for this change is that I want to use the library for testing supported TLS ciphers like what xmpp.net used to do. 

For that I built build a custom client where I can override the `get_ssl_context` method and return a very specific Context so I know exactly what I'm testing.