### PR TITLE
Use configured port when using a hostname instead of IP address.

### DIFF
--- a/slixmpp/xmlstream/xmlstream.py
+++ b/slixmpp/xmlstream/xmlstream.py
@@ -289,7 +289,8 @@ class XMLStream(asyncio.BaseProtocol):
 
         record = yield from self.pick_dns_answer(self.default_domain)
         if record is not None:
-            host, address, port = record
+            host, address, dns_port = record
+            port = dns_port if dns_port else self.address[1]
             self.address = (address, port)
             self._service_name = host
         else:


### PR DESCRIPTION
This seems to be the same issue as:

  https://dev.louiz.org/issues/3164

Using their suggested fix, if the DNS lookup doesn't return a port, use
the one passed in instead.

This seems to resolve the issue for me.