### PR TITLE
Use correct ssl_context, handle ssl handshake errors

### DIFF
--- a/slixmpp/xmlstream/xmlstream.py
+++ b/slixmpp/xmlstream/xmlstream.py
@@ -558,6 +558,14 @@ class XMLStream(asyncio.BaseProtocol):
             else:
                 self.event('ssl_invalid_chain', e)
             return False
+        except OSError as e:
+            log.error('SSL: Unable to handle TLS connection.')
+            if not self.event_handled('ssl_handshake_error'):
+                self.abort()
+            else:
+                self.event('ssl_handshake_error')
+            return False
+
         der_cert = transp.get_extra_info("ssl_object").getpeercert(True)
         pem_cert = ssl.DER_cert_to_PEM_cert(der_cert)
         self.event('ssl_cert', pem_cert)

--- a/slixmpp/xmlstream/xmlstream.py
+++ b/slixmpp/xmlstream/xmlstream.py
@@ -546,7 +546,7 @@ class XMLStream(asyncio.BaseProtocol):
             else:
                 transp, _ = await self.loop.create_connection(
                     lambda: self,
-                    ssl=self.ssl_context,
+                    ssl=ssl_context,
                     sock=self.socket,
                     server_hostname=self.default_domain
                 )

--- a/slixmpp/xmlstream/xmlstream.py
+++ b/slixmpp/xmlstream/xmlstream.py
@@ -558,7 +558,7 @@ class XMLStream(asyncio.BaseProtocol):
             else:
                 self.event('ssl_invalid_chain', e)
             return False
-        except OSError as e:
+        except OSError:
             log.error('SSL: Unable to handle TLS connection.')
             if not self.event_handled('ssl_handshake_error'):
                 self.abort()


### PR DESCRIPTION
- 735631f uses the correct SSL context for Python < 3.7
- 3b5e585 handles `OSError` exceptions. These happen (at least) when the SSL handshake fails, e.g. when you connect using an SSL context that only allows TLSv1, but the Server only supports TLSv1.2.