### PR TITLE
fixing deprecation warnings for pytest

### DIFF
--- a/slixmpp/test/slixtest.py
+++ b/slixmpp/test/slixtest.py
@@ -222,7 +222,7 @@ class SlixTest(unittest.TestCase):
             if Matcher is None:
                 raise ValueError("Unknown matching method.")
             test = Matcher(criteria)
-            self.failUnless(test.match(stanza),
+            self.assertTrue(test.match(stanza),
                     "Stanza did not match using %s method:\n" % method + \
                     "Criteria:\n%s\n" % str(criteria) + \
                     "Stanza:\n%s" % str(stanza))
@@ -280,7 +280,7 @@ class SlixTest(unittest.TestCase):
                 debug += "Generated stanza:\n%s\n" % highlight(tostring(stanza2.xml))
                 result = self.compare(xml, stanza.xml, stanza2.xml)
 
-            self.failUnless(result, debug)
+            self.assertTrue(result, debug)
 
     # ------------------------------------------------------------------
     # Methods for simulating stanza streams.
@@ -487,7 +487,7 @@ class SlixTest(unittest.TestCase):
             recv_xml.clear()
             recv_xml.attrib = attrib
 
-        self.failUnless(
+        self.assertTrue(
             self.compare(xml, recv_xml),
             "Stream headers do not match:\nDesired:\n%s\nReceived:\n%s" % (
                 '%s %s' % (xml.tag, xml.attrib),
@@ -543,7 +543,7 @@ class SlixTest(unittest.TestCase):
         xml = self.parse_xml(header2)
         sent_xml = self.parse_xml(sent_header2)
 
-        self.failUnless(
+        self.assertTrue(
             self.compare(xml, sent_xml),
             "Stream headers do not match:\nDesired:\n%s\nSent:\n%s" % (
                 header, sent_header))
@@ -557,12 +557,12 @@ class SlixTest(unittest.TestCase):
         if sent_data is None:
             self.fail("No stanza was sent.")
         if method == 'exact':
-            self.failUnless(self.compare(xml, sent_xml),
+            self.assertTrue(self.compare(xml, sent_xml),
                 "Features do not match.\nDesired:\n%s\nReceived:\n%s" % (
                     highlight(tostring(xml)), highlight(tostring(sent_xml))))
         elif method == 'mask':
             matcher = MatchXMLMask(xml)
-            self.failUnless(matcher.match(sent_xml),
+            self.assertTrue(matcher.match(sent_xml),
                 "Stanza did not match using %s method:\n" % method + \
                 "Criteria:\n%s\n" % highlight(tostring(xml)) + \
                 "Stanza:\n%s" % highlight(tostring(sent_xml)))

--- a/slixmpp/xmlstream/xmlstream.py
+++ b/slixmpp/xmlstream/xmlstream.py
@@ -995,4 +995,3 @@ class XMLStream(asyncio.BaseProtocol):
         :param exception: An unhandled exception object.
         """
         pass
-

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -23,7 +23,7 @@ class TestEvents(SlixTest):
         self.xmpp.event("test_event")
 
         msg = "Event was not triggered the correct number of times: %s"
-        self.failUnless(happened == [True, True], msg)
+        self.assertTrue(happened == [True, True], msg)
 
     def testDelEvent(self):
         """Test handler working, then deleted and not triggered"""
@@ -41,7 +41,7 @@ class TestEvents(SlixTest):
         self.xmpp.event("test_event", {})
 
         msg = "Event was not triggered the correct number of times: %s"
-        self.failUnless(happened == [True], msg % happened)
+        self.assertTrue(happened == [True], msg % happened)
 
     def testAddDelAddEvent(self):
         """Test adding, then removing, then adding an event handler."""
@@ -61,7 +61,7 @@ class TestEvents(SlixTest):
         self.xmpp.event("test_event", {})
 
         msg = "Event was not triggered the correct number of times: %s"
-        self.failUnless(happened == [True, True], msg % happened)
+        self.assertTrue(happened == [True, True], msg % happened)
 
     def testDisposableEvent(self):
         """Test disposable handler working, then not being triggered again."""
@@ -78,7 +78,7 @@ class TestEvents(SlixTest):
         self.xmpp.event("test_event", {})
 
         msg = "Event was not triggered the correct number of times: %s"
-        self.failUnless(happened == [True], msg % happened)
+        self.assertTrue(happened == [True], msg % happened)
 
 
 suite = unittest.TestLoader().loadTestsFromTestCase(TestEvents)

--- a/tests/test_overall.py
+++ b/tests/test_overall.py
@@ -16,11 +16,11 @@ class TestOverall(unittest.TestCase):
         """Testing all modules by compiling them"""
         src = '.%sslixmpp' % os.sep
         rx = re.compile('/[.]svn|.*26.*')
-        self.failUnless(compileall.compile_dir(src, rx=rx, quiet=True))
+        self.assertTrue(compileall.compile_dir(src, rx=rx, quiet=True))
 
     def testTabNanny(self):
         """Testing that indentation is consistent"""
-        self.failIf(tabnanny.check('..%sslixmpp' % os.sep))
+        self.assertFalse(tabnanny.check('..%sslixmpp' % os.sep))
 
 
 suite = unittest.TestLoader().loadTestsFromTestCase(TestOverall)

--- a/tests/test_stanza_base.py
+++ b/tests/test_stanza_base.py
@@ -9,37 +9,37 @@ class TestStanzaBase(SlixTest):
         """Test the 'to' interface of StanzaBase."""
         stanza = StanzaBase()
         stanza['to'] = 'user@example.com'
-        self.failUnless(str(stanza['to']) == 'user@example.com',
+        self.assertTrue(str(stanza['to']) == 'user@example.com',
             "Setting and retrieving stanza 'to' attribute did not work.")
 
     def testFrom(self):
         """Test the 'from' interface of StanzaBase."""
         stanza = StanzaBase()
         stanza['from'] = 'user@example.com'
-        self.failUnless(str(stanza['from']) == 'user@example.com',
+        self.assertTrue(str(stanza['from']) == 'user@example.com',
             "Setting and retrieving stanza 'from' attribute did not work.")
 
     def testPayload(self):
         """Test the 'payload' interface of StanzaBase."""
         stanza = StanzaBase()
-        self.failUnless(stanza['payload'] == [],
+        self.assertTrue(stanza['payload'] == [],
             "Empty stanza does not have an empty payload.")
 
         stanza['payload'] = ET.Element("{foo}foo")
-        self.failUnless(len(stanza['payload']) == 1,
+        self.assertTrue(len(stanza['payload']) == 1,
             "Stanza contents and payload do not match.")
 
         stanza['payload'] = ET.Element('{bar}bar')
-        self.failUnless(len(stanza['payload']) == 2,
+        self.assertTrue(len(stanza['payload']) == 2,
             "Stanza payload was not appended.")
 
         del stanza['payload']
-        self.failUnless(stanza['payload'] == [],
+        self.assertTrue(stanza['payload'] == [],
             "Stanza payload not cleared after deletion.")
 
         stanza['payload'] = [ET.Element('{foo}foo'),
                              ET.Element('{bar}bar')]
-        self.failUnless(len(stanza['payload']) == 2,
+        self.assertTrue(len(stanza['payload']) == 2,
             "Adding multiple elements to stanza's payload did not work.")
 
     def testClear(self):
@@ -49,9 +49,9 @@ class TestStanzaBase(SlixTest):
         stanza['payload'] = ET.Element("{foo}foo")
         stanza.clear()
 
-        self.failUnless(stanza['payload'] == [],
+        self.assertTrue(stanza['payload'] == [],
             "Stanza payload was not cleared after calling .clear()")
-        self.failUnless(str(stanza['to']) == "user@example.com",
+        self.assertTrue(str(stanza['to']) == "user@example.com",
             "Stanza attributes were not preserved after calling .clear()")
 
     def testReply(self):
@@ -63,9 +63,9 @@ class TestStanzaBase(SlixTest):
 
         stanza = stanza.reply()
 
-        self.failUnless(str(stanza['to'] == "sender@example.com"),
+        self.assertTrue(str(stanza['to'] == "sender@example.com"),
             "Stanza reply did not change 'to' attribute.")
-        self.failUnless(stanza['payload'] == [],
+        self.assertTrue(stanza['payload'] == [],
             "Stanza reply did not empty stanza payload.")
 
     def testError(self):
@@ -73,7 +73,7 @@ class TestStanzaBase(SlixTest):
         stanza = StanzaBase()
         stanza['type'] = 'get'
         stanza.error()
-        self.failUnless(stanza['type'] == 'error',
+        self.assertTrue(stanza['type'] == 'error',
             "Stanza type is not 'error' after calling error()")
 
 

--- a/tests/test_stanza_element.py
+++ b/tests/test_stanza_element.py
@@ -17,7 +17,7 @@ class TestElementBase(SlixTest):
                              "{%s}bar" % ns,
                              "{abc}baz",
                              "{%s}more" % ns])
-        self.failUnless(expected == result,
+        self.assertTrue(expected == result,
             "Incorrect namespace fixing result: %s" % str(result))
 
 
@@ -80,7 +80,7 @@ class TestElementBase(SlixTest):
                                     'lang': '',
                                     'bar': 'c',
                                     'baz': ''}]}
-        self.failUnless(values == expected,
+        self.assertTrue(values == expected,
             "Unexpected stanza values:\n%s\n%s" % (str(expected), str(values)))
 
 
@@ -170,13 +170,13 @@ class TestElementBase(SlixTest):
                     'meh': ''}
         for interface, value in expected.items():
             result = stanza[interface]
-            self.failUnless(result == value,
+            self.assertTrue(result == value,
                 "Incorrect stanza interface access result: %s" % result)
 
         # Test plugin interfaces
-        self.failUnless(isinstance(stanza['foobar'], TestStanzaPlugin),
+        self.assertTrue(isinstance(stanza['foobar'], TestStanzaPlugin),
                         "Incorrect plugin object result.")
-        self.failUnless(stanza['foobar']['fizz'] == 'c',
+        self.assertTrue(stanza['foobar']['fizz'] == 'c',
                         "Incorrect plugin subvalue result.")
 
     def testSetItem(self):
@@ -269,7 +269,7 @@ class TestElementBase(SlixTest):
           <foo xmlns="foo" />
         """)
 
-        self.failUnless(stanza._get_attr('bar') == '',
+        self.assertTrue(stanza._get_attr('bar') == '',
             "Incorrect value returned for an unset XML attribute.")
 
         stanza._set_attr('bar', 'a')
@@ -279,7 +279,7 @@ class TestElementBase(SlixTest):
           <foo xmlns="foo" bar="a" baz="b" />
         """)
 
-        self.failUnless(stanza._get_attr('bar') == 'a',
+        self.assertTrue(stanza._get_attr('bar') == 'a',
             "Retrieved XML attribute value is incorrect.")
 
         stanza._set_attr('bar', None)
@@ -289,7 +289,7 @@ class TestElementBase(SlixTest):
           <foo xmlns="foo" />
         """)
 
-        self.failUnless(stanza._get_attr('bar', 'c') == 'c',
+        self.assertTrue(stanza._get_attr('bar', 'c') == 'c',
             "Incorrect default value returned for an unset XML attribute.")
 
     def testGetSubText(self):
@@ -311,7 +311,7 @@ class TestElementBase(SlixTest):
                 return self._get_sub_text("wrapper/bar", default="not found")
 
         stanza = TestStanza()
-        self.failUnless(stanza['bar'] == 'not found',
+        self.assertTrue(stanza['bar'] == 'not found',
             "Default _get_sub_text value incorrect.")
 
         stanza['bar'] = 'found'
@@ -322,7 +322,7 @@ class TestElementBase(SlixTest):
             </wrapper>
           </foo>
         """)
-        self.failUnless(stanza['bar'] == 'found',
+        self.assertTrue(stanza['bar'] == 'found',
             "_get_sub_text value incorrect: %s." % stanza['bar'])
 
     def testSubElement(self):
@@ -481,45 +481,45 @@ class TestElementBase(SlixTest):
         register_stanza_plugin(TestStanza, TestStanzaPlugin)
 
         stanza = TestStanza()
-        self.failUnless(stanza.match("foo"),
+        self.assertTrue(stanza.match("foo"),
             "Stanza did not match its own tag name.")
 
-        self.failUnless(stanza.match("{foo}foo"),
+        self.assertTrue(stanza.match("{foo}foo"),
             "Stanza did not match its own namespaced name.")
 
         stanza['bar'] = 'a'
-        self.failUnless(stanza.match("foo@bar=a"),
+        self.assertTrue(stanza.match("foo@bar=a"),
             "Stanza did not match its own name with attribute value check.")
 
         stanza['baz'] = 'b'
-        self.failUnless(stanza.match("foo@bar=a@baz=b"),
+        self.assertTrue(stanza.match("foo@bar=a@baz=b"),
             "Stanza did not match its own name with multiple attributes.")
 
         stanza['qux'] = 'c'
-        self.failUnless(stanza.match("foo/qux"),
+        self.assertTrue(stanza.match("foo/qux"),
             "Stanza did not match with subelements.")
 
         stanza['qux'] = ''
-        self.failUnless(stanza.match("foo/qux") == False,
+        self.assertTrue(stanza.match("foo/qux") == False,
             "Stanza matched missing subinterface element.")
 
-        self.failUnless(stanza.match("foo/bar") == False,
+        self.assertTrue(stanza.match("foo/bar") == False,
             "Stanza matched nonexistent element.")
 
         stanza['plugin']['attrib'] = 'c'
-        self.failUnless(stanza.match("foo/plugin@attrib=c"),
+        self.assertTrue(stanza.match("foo/plugin@attrib=c"),
             "Stanza did not match with plugin and attribute.")
 
-        self.failUnless(stanza.match("foo/{http://test/slash/bar}plugin"),
+        self.assertTrue(stanza.match("foo/{http://test/slash/bar}plugin"),
             "Stanza did not match with namespaced plugin.")
 
         substanza = TestSubStanza()
         substanza['attrib'] = 'd'
         stanza.append(substanza)
-        self.failUnless(stanza.match("foo/sub@attrib=d"),
+        self.assertTrue(stanza.match("foo/sub@attrib=d"),
             "Stanza did not match with substanzas and attribute.")
 
-        self.failUnless(stanza.match("foo/{baz}sub"),
+        self.assertTrue(stanza.match("foo/{baz}sub"),
             "Stanza did not match with namespaced substanza.")
 
     def testComparisons(self):
@@ -533,19 +533,19 @@ class TestElementBase(SlixTest):
         stanza1 = TestStanza()
         stanza1['bar'] = 'a'
 
-        self.failUnless(stanza1,
+        self.assertTrue(stanza1,
             "Stanza object does not evaluate to True")
 
         stanza2 = TestStanza()
         stanza2['baz'] = 'b'
 
-        self.failUnless(stanza1 != stanza2,
+        self.assertTrue(stanza1 != stanza2,
             "Different stanza objects incorrectly compared equal.")
 
         stanza1['baz'] = 'b'
         stanza2['bar'] = 'a'
 
-        self.failUnless(stanza1 == stanza2,
+        self.assertTrue(stanza1 == stanza2,
             "Equal stanzas incorrectly compared inequal.")
 
     def testKeys(self):
@@ -561,12 +561,12 @@ class TestElementBase(SlixTest):
 
         stanza = TestStanza()
 
-        self.failUnless(set(stanza.keys()) == {'lang', 'bar', 'baz'},
+        self.assertTrue(set(stanza.keys()) == {'lang', 'bar', 'baz'},
             "Returned set of interface keys does not match expected.")
 
         stanza.enable('qux')
 
-        self.failUnless(set(stanza.keys()) == {'lang', 'bar', 'baz', 'qux'},
+        self.assertTrue(set(stanza.keys()) == {'lang', 'bar', 'baz', 'qux'},
             "Incorrect set of interface and plugin keys.")
 
     def testGet(self):
@@ -580,10 +580,10 @@ class TestElementBase(SlixTest):
         stanza = TestStanza()
         stanza['bar'] = 'a'
 
-        self.failUnless(stanza.get('bar') == 'a',
+        self.assertTrue(stanza.get('bar') == 'a',
             "Incorrect value returned by stanza.get")
 
-        self.failUnless(stanza.get('baz', 'b') == 'b',
+        self.assertTrue(stanza.get('baz', 'b') == 'b',
             "Incorrect default value returned by stanza.get")
 
     def testSubStanzas(self):
@@ -608,7 +608,7 @@ class TestElementBase(SlixTest):
         substanza2['qux'] = 'b'
 
         # Test appending substanzas
-        self.failUnless(len(stanza) == 0,
+        self.assertTrue(len(stanza) == 0,
             "Incorrect empty stanza size.")
 
         stanza.append(substanza1)
@@ -617,7 +617,7 @@ class TestElementBase(SlixTest):
             <foobar qux="a" />
           </foo>
         """, use_values=False)
-        self.failUnless(len(stanza) == 1,
+        self.assertTrue(len(stanza) == 1,
             "Incorrect stanza size with 1 substanza.")
 
         stanza.append(substanza2)
@@ -627,7 +627,7 @@ class TestElementBase(SlixTest):
             <foobar qux="b" />
           </foo>
         """, use_values=False)
-        self.failUnless(len(stanza) == 2,
+        self.assertTrue(len(stanza) == 2,
             "Incorrect stanza size with 2 substanzas.")
 
         # Test popping substanzas
@@ -643,7 +643,7 @@ class TestElementBase(SlixTest):
         results = []
         for substanza in stanza:
             results.append(substanza['qux'])
-        self.failUnless(results == ['b', 'a'],
+        self.assertTrue(results == ['b', 'a'],
             "Iteration over substanzas failed: %s." % str(results))
 
     def testCopy(self):
@@ -659,11 +659,11 @@ class TestElementBase(SlixTest):
 
         stanza2 = stanza1.__copy__()
 
-        self.failUnless(stanza1 == stanza2,
+        self.assertTrue(stanza1 == stanza2,
             "Copied stanzas are not equal to each other.")
 
         stanza1['baz'] = 'b'
-        self.failUnless(stanza1 != stanza2,
+        self.assertTrue(stanza1 != stanza2,
             "Divergent stanza copies incorrectly compared equal.")
 
     def testExtension(self):
@@ -701,7 +701,7 @@ class TestElementBase(SlixTest):
           </foo>
         """)
 
-        self.failUnless(stanza['extended'] == 'testing',
+        self.assertTrue(stanza['extended'] == 'testing',
                 "Could not retrieve stanza extension value.")
 
         del stanza['extended']

--- a/tests/test_stanza_error.py
+++ b/tests/test_stanza_error.py
@@ -34,7 +34,7 @@ class TestErrorStanzas(SlixTest):
           </message>
         """)
 
-        self.failUnless(msg['error']['condition'] == 'item-not-found', "Error condition doesn't match.")
+        self.assertTrue(msg['error']['condition'] == 'item-not-found', "Error condition doesn't match.")
 
         msg['error']['condition'] = 'resource-constraint'
 

--- a/tests/test_stanza_gmail.py
+++ b/tests/test_stanza_gmail.py
@@ -62,30 +62,30 @@ class TestGmail(SlixTest):
 
         iq = self.Iq(xml=xml)
         mailbox = iq['mailbox']
-        self.failUnless(mailbox['result-time'] == '1118012394209', "result-time doesn't match")
-        self.failUnless(mailbox['url'] == 'http://mail.google.com/mail', "url doesn't match")
-        self.failUnless(mailbox['matched'] == '95', "total-matched incorrect")
-        self.failUnless(mailbox['estimate'] == False, "total-estimate incorrect")
-        self.failUnless(len(mailbox['threads']) == 1, "could not extract message threads")
+        self.assertTrue(mailbox['result-time'] == '1118012394209', "result-time doesn't match")
+        self.assertTrue(mailbox['url'] == 'http://mail.google.com/mail', "url doesn't match")
+        self.assertTrue(mailbox['matched'] == '95', "total-matched incorrect")
+        self.assertTrue(mailbox['estimate'] == False, "total-estimate incorrect")
+        self.assertTrue(len(mailbox['threads']) == 1, "could not extract message threads")
 
         thread = mailbox['threads'][0]
-        self.failUnless(thread['tid'] == '1172320964060972012', "thread tid doesn't match")
-        self.failUnless(thread['participation'] == '1', "thread participation incorrect")
-        self.failUnless(thread['messages'] == '28', "thread message count incorrect")
-        self.failUnless(thread['date'] == '1118012394209', "thread date doesn't match")
-        self.failUnless(thread['url'] == 'http://mail.google.com/mail?view=cv', "thread url doesn't match")
-        self.failUnless(thread['labels'] == 'act1scene3', "thread labels incorrect")
-        self.failUnless(thread['subject'] == 'Put thy rapier up.', "thread subject doesn't match")
-        self.failUnless(thread['snippet'] == "Ay, ay, a scratch, a scratch; marry, 'tis enough.", "snippet doesn't match")
-        self.failUnless(len(thread['senders']) == 3, "could not extract senders")
+        self.assertTrue(thread['tid'] == '1172320964060972012', "thread tid doesn't match")
+        self.assertTrue(thread['participation'] == '1', "thread participation incorrect")
+        self.assertTrue(thread['messages'] == '28', "thread message count incorrect")
+        self.assertTrue(thread['date'] == '1118012394209', "thread date doesn't match")
+        self.assertTrue(thread['url'] == 'http://mail.google.com/mail?view=cv', "thread url doesn't match")
+        self.assertTrue(thread['labels'] == 'act1scene3', "thread labels incorrect")
+        self.assertTrue(thread['subject'] == 'Put thy rapier up.', "thread subject doesn't match")
+        self.assertTrue(thread['snippet'] == "Ay, ay, a scratch, a scratch; marry, 'tis enough.", "snippet doesn't match")
+        self.assertTrue(len(thread['senders']) == 3, "could not extract senders")
 
         sender1 = thread['senders'][0]
-        self.failUnless(sender1['name'] == 'Me', "sender name doesn't match")
-        self.failUnless(sender1['address'] == 'romeo@gmail.com', "sender address doesn't match")
-        self.failUnless(sender1['originator'] == True, "sender originator incorrect")
-        self.failUnless(sender1['unread'] == False, "sender unread incorrectly True")
+        self.assertTrue(sender1['name'] == 'Me', "sender name doesn't match")
+        self.assertTrue(sender1['address'] == 'romeo@gmail.com', "sender address doesn't match")
+        self.assertTrue(sender1['originator'] == True, "sender originator incorrect")
+        self.assertTrue(sender1['unread'] == False, "sender unread incorrectly True")
 
         sender2 = thread['senders'][2]
-        self.failUnless(sender2['unread'] == True, "sender unread incorrectly False")
+        self.assertTrue(sender2['unread'] == True, "sender unread incorrectly False")
 
 suite = unittest.TestLoader().loadTestsFromTestCase(TestGmail)

--- a/tests/test_stanza_iq.py
+++ b/tests/test_stanza_iq.py
@@ -70,7 +70,7 @@ class TestIqStanzas(SlixTest):
           </iq>
         """)
 
-        self.failUnless(iq['query'] == 'query_ns2', "Query namespace doesn't match")
+        self.assertTrue(iq['query'] == 'query_ns2', "Query namespace doesn't match")
 
         del iq['query']
         self.check(iq, """

--- a/tests/test_stanza_message.py
+++ b/tests/test_stanza_message.py
@@ -18,7 +18,7 @@ class TestMessageStanzas(SlixTest):
         msg['type'] = 'groupchat'
         msg['body'] = "this is a message"
         msg = msg.reply()
-        self.failUnless(str(msg['to']) == 'room@someservice.someserver.tld')
+        self.assertTrue(str(msg['to']) == 'room@someservice.someserver.tld')
 
     def testHTMLPlugin(self):
         "Test message/html/body stanza"

--- a/tests/test_stanza_presence.py
+++ b/tests/test_stanza_presence.py
@@ -15,7 +15,7 @@ class TestPresenceStanzas(SlixTest):
         p = self.Presence()
         p['type'] = 'available'
         self.check(p, "<presence />")
-        self.failUnless(p['type'] == 'available',
+        self.assertTrue(p['type'] == 'available',
             "Incorrect presence['type'] for type 'available': %s" % p['type'])
 
         for showtype in ['away', 'chat', 'dnd', 'xa']:
@@ -23,7 +23,7 @@ class TestPresenceStanzas(SlixTest):
             self.check(p, """
               <presence><show>%s</show></presence>
             """ % showtype)
-            self.failUnless(p['type'] == showtype,
+            self.assertTrue(p['type'] == showtype,
                 "Incorrect presence['type'] for type '%s'" % showtype)
 
         p['type'] = None
@@ -47,10 +47,10 @@ class TestPresenceStanzas(SlixTest):
         c.add_event_handler("changed_status", handlechangedpresence)
         c._handle_presence(p)
 
-        self.failUnless(happened == [],
+        self.assertTrue(happened == [],
             "changed_status event triggered for extra unavailable presence")
         roster = c.roster['crap@wherever']
-        self.failUnless(roster['bill@chadmore.com'].resources == {},
+        self.assertTrue(roster['bill@chadmore.com'].resources == {},
             "Roster updated for superfulous unavailable presence")
 
     def testNickPlugin(self):

--- a/tests/test_stanza_roster.py
+++ b/tests/test_stanza_roster.py
@@ -61,7 +61,7 @@ class TestRosterStanzas(SlixTest):
         debug = "Roster items don't match after retrieval."
         debug += "\nReturned: %s" % str(iq['roster']['items'])
         debug += "\nExpected: %s" % str(expected)
-        self.failUnless(iq['roster']['items'] == expected, debug)
+        self.assertTrue(iq['roster']['items'] == expected, debug)
 
     def testDelItems(self):
         """Test clearing items from a roster stanza."""

--- a/tests/test_stanza_xep_0030.py
+++ b/tests/test_stanza_xep_0030.py
@@ -258,7 +258,7 @@ class TestDisco(SlixTest):
                     ('client', 'pc', 'no', None),
                     ('client', 'pc', 'en', None),
                     ('client', 'pc', 'fr', None)}
-        self.failUnless(iq['disco_info']['identities'] == expected,
+        self.assertTrue(iq['disco_info']['identities'] == expected,
                 "Identities do not match:\n%s\n%s" % (
                     expected,
                     iq['disco_info']['identities']))
@@ -276,7 +276,7 @@ class TestDisco(SlixTest):
 
         expected = {('client', 'pc', 'no', None)}
         result = iq['disco_info'].get_identities(lang='no')
-        self.failUnless(result == expected,
+        self.assertTrue(result == expected,
                 "Identities do not match:\n%s\n%s" % (
                     expected, result))
 
@@ -337,7 +337,7 @@ class TestDisco(SlixTest):
         iq['disco_info'].add_feature('baz')
 
         expected = {'foo', 'bar', 'baz'}
-        self.failUnless(iq['disco_info']['features'] == expected,
+        self.assertTrue(iq['disco_info']['features'] == expected,
                 "Features do not match:\n%s\n%s" % (
                     expected,
                     iq['disco_info']['features']))
@@ -475,7 +475,7 @@ class TestDisco(SlixTest):
         expected = {('user@localhost', None, None),
                     ('user@localhost', 'foo', None),
                     ('test@localhost', 'bar', 'Tester')}
-        self.failUnless(iq['disco_items']['items'] == expected,
+        self.assertTrue(iq['disco_items']['items'] == expected,
                 "Items do not match:\n%s\n%s" % (
                     expected,
                     iq['disco_items']['items']))

--- a/tests/test_stanza_xep_0050.py
+++ b/tests/test_stanza_xep_0050.py
@@ -17,13 +17,13 @@ class TestAdHocCommandStanzas(SlixTest):
         iq['command']['node'] = 'foo'
 
         iq['command']['action'] = 'execute'
-        self.failUnless(iq['command']['action'] == 'execute')
+        self.assertTrue(iq['command']['action'] == 'execute')
 
         iq['command']['action'] = 'complete'
-        self.failUnless(iq['command']['action'] == 'complete')
+        self.assertTrue(iq['command']['action'] == 'complete')
 
         iq['command']['action'] = 'cancel'
-        self.failUnless(iq['command']['action'] == 'cancel')
+        self.assertTrue(iq['command']['action'] == 'cancel')
 
     def testSetActions(self):
         """Test setting next actions in a command stanza."""
@@ -98,7 +98,7 @@ class TestAdHocCommandStanzas(SlixTest):
                  ('error', "I can't let you do that")]
         iq['command']['notes'] = notes
 
-        self.failUnless(iq['command']['notes'] == notes,
+        self.assertTrue(iq['command']['notes'] == notes,
                 "Notes don't match: %s %s" % (notes, iq['command']['notes']))
 
         self.check(iq, """

--- a/tests/test_stanza_xep_0059.py
+++ b/tests/test_stanza_xep_0059.py
@@ -24,7 +24,7 @@ class TestSetStanzas(SlixTest):
         """
         s = Set(ET.fromstring(xml_string))
         expected = '10'
-        self.failUnless(s['first_index'] == expected)
+        self.assertTrue(s['first_index'] == expected)
 
     def testDelFirstIndex(self):
         xml_string = """
@@ -57,7 +57,7 @@ class TestSetStanzas(SlixTest):
         """
         s = Set(ET.fromstring(xml_string))
         expected = True
-        self.failUnless(s['before'] == expected)
+        self.assertTrue(s['before'] == expected)
 
     def testGetBefore(self):
         xml_string = """
@@ -89,7 +89,7 @@ class TestSetStanzas(SlixTest):
         """
         s = Set(ET.fromstring(xml_string))
         expected = 'id'
-        self.failUnless(s['before'] == expected)
+        self.assertTrue(s['before'] == expected)
 
     def testGetBeforeVal(self):
         xml_string = """

--- a/tests/test_stream_handlers.py
+++ b/tests/test_stream_handlers.py
@@ -112,7 +112,7 @@ class TestHandlers(SlixTest):
         # Check that the waiter is no longer registered
         waiter_exists = self.xmpp.remove_handler('IqWait_test2')
 
-        self.failUnless(waiter_exists == False,
+        self.assertTrue(waiter_exists == False,
             "Waiter handler was not removed.")
 
     def testIqCallback(self):
@@ -145,7 +145,7 @@ class TestHandlers(SlixTest):
           </iq>
         """)
 
-        self.failUnless(events == ['foo'],
+        self.assertTrue(events == ['foo'],
                 "Iq callback was not executed: %s" % events)
 
     def testMultipleHandlersForStanza(self):

--- a/tests/test_stream_roster.py
+++ b/tests/test_stream_roster.py
@@ -52,7 +52,7 @@ class TestStreamRoster(SlixTest):
                           pending_out=True,
                           groups=['Friends', 'Examples'])
 
-        self.failUnless(len(roster_updates) == 1,
+        self.assertTrue(len(roster_updates) == 1,
                 "Wrong number of roster_update events fired: %s (should be 1)" % len(roster_updates))
 
     def testRosterSet(self):
@@ -89,7 +89,7 @@ class TestStreamRoster(SlixTest):
                           groups=['Friends', 'Examples'])
 
 
-        self.failUnless('roster_update' in events,
+        self.assertTrue('roster_update' in events,
                 "Roster updated event not triggered: %s" % events)
 
     def testRosterPushRemove(self):
@@ -188,7 +188,7 @@ class TestStreamRoster(SlixTest):
           </iq>
         """)
 
-        self.failUnless(events == ['roster_callback'],
+        self.assertTrue(events == ['roster_callback'],
                  "Roster timeout event not triggered: %s." % events)
 
     def testRosterUnicode(self):
@@ -209,7 +209,7 @@ class TestStreamRoster(SlixTest):
                           groups=['Unicode'])
 
         jids = list(self.xmpp.client_roster.keys())
-        self.failUnless(jids == ['andré@foo'],
+        self.assertTrue(jids == ['andré@foo'],
                  "Too many roster entries found: %s" % jids)
 
         self.recv("""
@@ -223,7 +223,7 @@ class TestStreamRoster(SlixTest):
         expected = {'bar': {'status':'Testing',
                             'show':'away',
                             'priority':0}}
-        self.failUnless(result == expected,
+        self.assertTrue(result == expected,
                 "Unexpected roster values: %s" % result)
 
     def testSendLastPresence(self):

--- a/tests/test_stream_xep_0050.py
+++ b/tests/test_stream_xep_0050.py
@@ -626,7 +626,7 @@ class TestAdHocCommands(SlixTest):
           </iq>
         """)
 
-        self.failUnless(results == ['foo', 'bar', 'baz'],
+        self.assertTrue(results == ['foo', 'bar', 'baz'],
                 'Incomplete command workflow: %s' % results)
 
     def testClientAPICancel(self):
@@ -689,7 +689,7 @@ class TestAdHocCommands(SlixTest):
           </iq>
         """)
 
-        self.failUnless(results == ['foo', 'bar'],
+        self.assertTrue(results == ['foo', 'bar'],
                 'Incomplete command workflow: %s' % results)
 
     def testClientAPIError(self):
@@ -727,7 +727,7 @@ class TestAdHocCommands(SlixTest):
           </iq>
         """)
 
-        self.failUnless(results == ['foo'],
+        self.assertTrue(results == ['foo'],
                 'Incomplete command workflow: %s' % results)
 
     def testClientAPIErrorStrippedResponse(self):
@@ -762,7 +762,7 @@ class TestAdHocCommands(SlixTest):
           </iq>
         """)
 
-        self.failUnless(results == ['foo'],
+        self.assertTrue(results == ['foo'],
                 'Incomplete command workflow: %s' % results)
 
 

--- a/tests/test_stream_xep_0085.py
+++ b/tests/test_stream_xep_0085.py
@@ -50,7 +50,7 @@ class TestStreamChatStates(SlixTest):
         """)
 
         expected = ['active', 'inactive', 'paused', 'composing', 'gone']
-        self.failUnless(results == expected,
+        self.assertTrue(results == expected,
                 "Chat state event not handled: %s" % results)
 
 

--- a/tests/test_stream_xep_0249.py
+++ b/tests/test_stream_xep_0249.py
@@ -35,7 +35,7 @@ class TestStreamDirectInvite(SlixTest):
           </message>
         """)
 
-        self.failUnless(events == [True],
+        self.assertTrue(events == [True],
                 "Event not raised: %s" % events)
 
     def testSentDirectInvite(self):

--- a/tests/test_stream_xep_0323.py
+++ b/tests/test_stream_xep_0323.py
@@ -561,19 +561,19 @@ class TestStreamSensorData(SlixTest):
             </message>
             """)
 
-        self.assertTrue(results, ["accepted","fields","done"])
+        self.assertEqual(results, ["accepted","fields","done"])
         # self.assertIn("nodeId", callback_data);
         self.assertTrue("nodeId" in callback_data)
-        self.assertTrue(callback_data["nodeId"], "Device33")
+        self.assertEqual(callback_data["nodeId"], "Device33")
         # self.assertIn("timestamp", callback_data);
         self.assertTrue("timestamp" in callback_data)
-        self.assertTrue(callback_data["timestamp"], "2000-01-01T00:01:02")
+        self.assertEqual(callback_data["timestamp"], "2000-01-01T00:01:02")
         #self.assertIn("field_Voltage", callback_data);
         self.assertTrue("field_Voltage" in callback_data)
-        self.assertTrue(callback_data["field_Voltage"], {"name": "Voltage", "value": "230.4", "typename": "numeric", "unit": "V", "flags": {"invoiced": "true"}})
+        self.assertEqual(callback_data["field_Voltage"], {"name": "Voltage", "value": "230.4", "typename": "numeric", "unit": "V", "flags": {"invoiced": "true"}})
         #self.assertIn("field_TestBool", callback_data);
         self.assertTrue("field_TestBool" in callback_data)
-        self.assertTrue(callback_data["field_TestBool"], {"name": "TestBool", "value": "true", "typename": "boolean" })
+        self.assertEqual(callback_data["field_TestBool"], {"name": "TestBool", "value": "true", "typename": "boolean" })
 
     def testServiceDiscoveryClient(self):
         self.stream_start(mode='client',
@@ -675,16 +675,16 @@ class TestStreamSensorData(SlixTest):
             </message>
             """)
 
-        self.assertTrue(results, ["accepted","failure"]);
+        self.assertEqual(results, ["accepted","failure"]);
         # self.assertIn("nodeId", callback_data);
         self.assertTrue("nodeId" in callback_data)
-        self.assertTrue(callback_data["nodeId"], "Device33")
+        self.assertEqual(callback_data["nodeId"], "Device33")
         # self.assertIn("timestamp", callback_data);
         self.assertTrue("timestamp" in callback_data)
-        self.assertTrue(callback_data["timestamp"], "2013-03-07T17:13:30")
+        self.assertEqual(callback_data["timestamp"], "2013-03-07T17:13:30")
         # self.assertIn("error_msg", callback_data);
         self.assertTrue("error_msg" in callback_data)
-        self.assertTrue(callback_data["error_msg"], "Timeout.")
+        self.assertEqual(callback_data["error_msg"], "Timeout.")
 
     def testDelayedRequest(self):
         self.stream_start(mode='component',
@@ -1071,19 +1071,19 @@ class TestStreamSensorData(SlixTest):
             </message>
             """)
 
-        self.assertTrue(results, ["queued","started","fields","done"]);
+        self.assertEqual(results, ["queued","started","fields","done"]);
         # self.assertIn("nodeId", callback_data);
         self.assertTrue("nodeId" in callback_data)
-        self.assertTrue(callback_data["nodeId"], "Device33")
+        self.assertEqual(callback_data["nodeId"], "Device33")
         # self.assertIn("timestamp", callback_data);
         self.assertTrue("timestamp" in callback_data)
-        self.assertTrue(callback_data["timestamp"], "2000-01-01T00:01:02")
+        self.assertEqual(callback_data["timestamp"], "2000-01-01T00:01:02")
         # self.assertIn("field_Voltage", callback_data);
         self.assertTrue("field_Voltage" in callback_data)
-        self.assertTrue(callback_data["field_Voltage"], {"name": "Voltage", "value": "230.4", "typename": "numeric", "unit": "V", "flags": {"invoiced": "true"}})
+        self.assertEqual(callback_data["field_Voltage"], {"name": "Voltage", "value": "230.4", "typename": "numeric", "unit": "V", "flags": {"invoiced": "true"}})
         # self.assertIn("field_TestBool", callback_data);
         self.assertTrue("field_TestBool" in callback_data)
-        self.assertTrue(callback_data["field_TestBool"], {"name": "TestBool", "value": "true", "typename": "boolean" })
+        self.assertEqual(callback_data["field_TestBool"], {"name": "TestBool", "value": "true", "typename": "boolean" })
 
 
     def testRequestFieldsCancelAPI(self):
@@ -1139,7 +1139,7 @@ class TestStreamSensorData(SlixTest):
             </iq>
             """)
 
-        self.assertTrue(results, ["accepted","cancelled"])
+        self.assertEqual(results, ["accepted","cancelled"])
 
     def testDelayedRequestCancel(self):
         self.stream_start(mode='component',

--- a/tests/test_stream_xep_0323.py
+++ b/tests/test_stream_xep_0323.py
@@ -456,7 +456,7 @@ class TestStreamSensorData(SlixTest):
             </iq>
             """)
 
-        self.failUnless(results == ["rejected"],
+        self.assertTrue(results == ["rejected"],
                 "Rejected callback was not properly executed")
 
     def testRequestAcceptedAPI(self):
@@ -493,7 +493,7 @@ class TestStreamSensorData(SlixTest):
             </iq>
             """)
 
-        self.failUnless(results == ["accepted"],
+        self.assertTrue(results == ["accepted"],
                 "Accepted callback was not properly executed")
 
     def testRequestFieldsAPI(self):
@@ -561,19 +561,19 @@ class TestStreamSensorData(SlixTest):
             </message>
             """)
 
-        self.failUnlessEqual(results, ["accepted","fields","done"])
+        self.assertTrue(results, ["accepted","fields","done"])
         # self.assertIn("nodeId", callback_data);
         self.assertTrue("nodeId" in callback_data)
-        self.failUnlessEqual(callback_data["nodeId"], "Device33")
+        self.assertTrue(callback_data["nodeId"], "Device33")
         # self.assertIn("timestamp", callback_data);
         self.assertTrue("timestamp" in callback_data)
-        self.failUnlessEqual(callback_data["timestamp"], "2000-01-01T00:01:02")
+        self.assertTrue(callback_data["timestamp"], "2000-01-01T00:01:02")
         #self.assertIn("field_Voltage", callback_data);
         self.assertTrue("field_Voltage" in callback_data)
-        self.failUnlessEqual(callback_data["field_Voltage"], {"name": "Voltage", "value": "230.4", "typename": "numeric", "unit": "V", "flags": {"invoiced": "true"}})
+        self.assertTrue(callback_data["field_Voltage"], {"name": "Voltage", "value": "230.4", "typename": "numeric", "unit": "V", "flags": {"invoiced": "true"}})
         #self.assertIn("field_TestBool", callback_data);
         self.assertTrue("field_TestBool" in callback_data)
-        self.failUnlessEqual(callback_data["field_TestBool"], {"name": "TestBool", "value": "true", "typename": "boolean" })
+        self.assertTrue(callback_data["field_TestBool"], {"name": "TestBool", "value": "true", "typename": "boolean" })
 
     def testServiceDiscoveryClient(self):
         self.stream_start(mode='client',
@@ -675,16 +675,16 @@ class TestStreamSensorData(SlixTest):
             </message>
             """)
 
-        self.failUnlessEqual(results, ["accepted","failure"]);
+        self.assertTrue(results, ["accepted","failure"]);
         # self.assertIn("nodeId", callback_data);
         self.assertTrue("nodeId" in callback_data)
-        self.failUnlessEqual(callback_data["nodeId"], "Device33")
+        self.assertTrue(callback_data["nodeId"], "Device33")
         # self.assertIn("timestamp", callback_data);
         self.assertTrue("timestamp" in callback_data)
-        self.failUnlessEqual(callback_data["timestamp"], "2013-03-07T17:13:30")
+        self.assertTrue(callback_data["timestamp"], "2013-03-07T17:13:30")
         # self.assertIn("error_msg", callback_data);
         self.assertTrue("error_msg" in callback_data)
-        self.failUnlessEqual(callback_data["error_msg"], "Timeout.")
+        self.assertTrue(callback_data["error_msg"], "Timeout.")
 
     def testDelayedRequest(self):
         self.stream_start(mode='component',
@@ -1071,19 +1071,19 @@ class TestStreamSensorData(SlixTest):
             </message>
             """)
 
-        self.failUnlessEqual(results, ["queued","started","fields","done"]);
+        self.assertTrue(results, ["queued","started","fields","done"]);
         # self.assertIn("nodeId", callback_data);
         self.assertTrue("nodeId" in callback_data)
-        self.failUnlessEqual(callback_data["nodeId"], "Device33")
+        self.assertTrue(callback_data["nodeId"], "Device33")
         # self.assertIn("timestamp", callback_data);
         self.assertTrue("timestamp" in callback_data)
-        self.failUnlessEqual(callback_data["timestamp"], "2000-01-01T00:01:02")
+        self.assertTrue(callback_data["timestamp"], "2000-01-01T00:01:02")
         # self.assertIn("field_Voltage", callback_data);
         self.assertTrue("field_Voltage" in callback_data)
-        self.failUnlessEqual(callback_data["field_Voltage"], {"name": "Voltage", "value": "230.4", "typename": "numeric", "unit": "V", "flags": {"invoiced": "true"}})
+        self.assertTrue(callback_data["field_Voltage"], {"name": "Voltage", "value": "230.4", "typename": "numeric", "unit": "V", "flags": {"invoiced": "true"}})
         # self.assertIn("field_TestBool", callback_data);
         self.assertTrue("field_TestBool" in callback_data)
-        self.failUnlessEqual(callback_data["field_TestBool"], {"name": "TestBool", "value": "true", "typename": "boolean" })
+        self.assertTrue(callback_data["field_TestBool"], {"name": "TestBool", "value": "true", "typename": "boolean" })
 
 
     def testRequestFieldsCancelAPI(self):
@@ -1139,7 +1139,7 @@ class TestStreamSensorData(SlixTest):
             </iq>
             """)
 
-        self.failUnlessEqual(results, ["accepted","cancelled"])
+        self.assertTrue(results, ["accepted","cancelled"])
 
     def testDelayedRequestCancel(self):
         self.stream_start(mode='component',

--- a/tests/test_tostring.py
+++ b/tests/test_tostring.py
@@ -25,7 +25,7 @@ class TestToString(SlixTest):
         else:
             xml=original
         result = tostring(xml, **kwargs)
-        self.failUnless(result == expected, "%s: %s" % (message, result))
+        self.assertTrue(result == expected, "%s: %s" % (message, result))
 
     def testXMLEscape(self):
         """Test escaping XML special characters."""
@@ -34,7 +34,7 @@ class TestToString(SlixTest):
         desired = """&lt;foo bar=&quot;baz&quot;&gt;&apos;Hi"""
         desired += """ &amp; welcome!&apos;&lt;/foo&gt;"""
 
-        self.failUnless(escaped == desired,
+        self.assertTrue(escaped == desired,
             "XML escaping did not work: %s." % escaped)
 
     def testEmptyElement(self):
@@ -99,7 +99,7 @@ class TestToString(SlixTest):
         msg['body'] = utf8_message.decode('utf-8')
         expected = '<message><body>\xe0\xb2\xa0_\xe0\xb2\xa0</body></message>'
         result = msg.__str__()
-        self.failUnless(result == expected,
+        self.assertTrue(result == expected,
              "Stanza Unicode handling is incorrect: %s" % result)
 
     def testXMLLang(self):
@@ -112,7 +112,7 @@ class TestToString(SlixTest):
 
         expected = '<message xml:lang="no" />'
         result = msg.__str__()
-        self.failUnless(expected == result,
+        self.assertTrue(expected == result,
             "Serialization with xml:lang failed: %s" % result)
 
 


### PR DESCRIPTION
fixes some deprecation warnings when running tests with pytest. 

`python3 ./run_tests.py` still works as expected.