### PR TITLE
Fix XML parsing error in complex installations

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setup(
     platforms=['any'],
     packages=packages,
     ext_modules=ext_modules,
-    install_requires=['aiodns>=1.0', 'pyasn1', 'pyasn1_modules', 'aiohttp'],
+    install_requires=['aiodns>=1.0', 'pyasn1', 'pyasn1_modules', 'aiohttp', 'lxml'],
     classifiers=CLASSIFIERS,
     cmdclass={'test': TestCommand}
 )

--- a/slixmpp/version.py
+++ b/slixmpp/version.py
@@ -9,5 +9,5 @@
 # We don't want to have to import the entire library
 # just to get the version info for setup.py
 
-__version__ = '1.4.2'
+__version__ = '1.4.2_ha'
 __version_info__ = (1, 4, 2)

--- a/slixmpp/version.py
+++ b/slixmpp/version.py
@@ -9,5 +9,5 @@
 # We don't want to have to import the entire library
 # just to get the version info for setup.py
 
-__version__ = '1.4.2_ha'
-__version_info__ = (1, 4, 2)
+__version__ = '9.9'
+__version_info__ = (9, 9, 0)

--- a/slixmpp/xmlstream/stanzabase.py
+++ b/slixmpp/xmlstream/stanzabase.py
@@ -17,7 +17,8 @@ from __future__ import with_statement, unicode_literals
 import copy
 import logging
 import weakref
-from xml.etree import cElementTree as ET
+# from xml.etree import cElementTree as ET
+from lxml import etree as ET
 
 from slixmpp.xmlstream import JID
 from slixmpp.xmlstream.tostring import tostring

--- a/slixmpp/xmlstream/stanzabase.py
+++ b/slixmpp/xmlstream/stanzabase.py
@@ -1040,7 +1040,7 @@ class ElementBase(object):
             elements = self.xml.findall(element_path)
             try:
                 parent = self.xml.find(parent_path)
-            except TypeError:
+            except:
                 parent = None
                 
             if elements:

--- a/slixmpp/xmlstream/stanzabase.py
+++ b/slixmpp/xmlstream/stanzabase.py
@@ -1038,8 +1038,11 @@ class ElementBase(object):
             parent_path = "/".join(path[:len(path) - level - 1])
 
             elements = self.xml.findall(element_path)
-            parent = self.xml.find(parent_path)
-
+            try:
+                parent = self.xml.find(parent_path)
+            except TypeError:
+                parent = None
+                
             if elements:
                 if parent is None:
                     parent = self.xml

--- a/slixmpp/xmlstream/xmlstream.py
+++ b/slixmpp/xmlstream/xmlstream.py
@@ -19,7 +19,8 @@ import ssl
 import weakref
 import uuid
 
-import xml.etree.ElementTree as ET
+# import xml.etree.ElementTree as ET
+from lxml import etree as ET
 
 from slixmpp.xmlstream.asyncio import asyncio
 from slixmpp.xmlstream import tostring


### PR DESCRIPTION
Fix for XML parsing errors that occur when slixmpp is used in programs that load a lot of modules (i.e. Home Assistant).

Fixes issue https://lab.louiz.org/poezio/slixmpp/issues/3429