### PR TITLE
Fixed 31 issues of type: PYTHON_E225 throughout 9 files in repo.

### DIFF
--- a/examples/IoT_TestDevice.py
+++ b/examples/IoT_TestDevice.py
@@ -32,10 +32,10 @@ class IoT_TestDevice(slixmpp.ClientXMPP):
         slixmpp.ClientXMPP.__init__(self, jid, password)
         self.add_event_handler("session_start", self.session_start)
         self.add_event_handler("message", self.message)
-        self.device=None
-        self.releaseMe=False
-        self.beServer=True
-        self.clientJID=None
+        self.device = None
+        self.releaseMe = False
+        self.beServer = True
+        self.clientJID = None
 
     def datacallback(self,from_jid,result,nodeId=None,timestamp=None,fields=None,error_msg=None):
         """
@@ -46,11 +46,11 @@ class IoT_TestDevice(slixmpp.ClientXMPP):
 
     def beClientOrServer(self,server=True,clientJID=None ):
         if server:
-            self.beServer=True
-            self.clientJID=None
+            self.beServer = True
+            self.clientJID = None
         else:
-            self.beServer=False
-            self.clientJID=clientJID
+            self.beServer = False
+            self.clientJID = clientJID
 
     def testForRelease(self):
         # todo thread safe
@@ -58,24 +58,24 @@ class IoT_TestDevice(slixmpp.ClientXMPP):
 
     def doReleaseMe(self):
         # todo thread safe
-        self.releaseMe=True
+        self.releaseMe = True
 
     def addDevice(self, device):
-        self.device=device
+        self.device = device
 
     def session_start(self, event):
         self.send_presence()
         self.get_roster()
         # tell your preffered friend that you are alive
-        self.send_message(mto='jocke@jabber.sust.se', mbody=self.boundjid.bare +' is now online use xep_323 stanza to talk to me')
+        self.send_message(mto='jocke@jabber.sust.se', mbody=self.boundjid.bare + ' is now online use xep_323 stanza to talk to me')
 
         if not(self.beServer):
-            session=self['xep_0323'].request_data(self.boundjid.full,self.clientJID,self.datacallback)
+            session = self['xep_0323'].request_data(self.boundjid.full,self.clientJID,self.datacallback)
 
     def message(self, msg):
         if msg['type'] in ('chat', 'normal'):
             logging.debug("got normal chat message" + str(msg))
-            ip=urlopen('http://icanhazip.com').read()
+            ip = urlopen('http://icanhazip.com').read()
             msg.reply("Hi I am " + self.boundjid.full + " and I am on IP " + ip).send()
         else:
             logging.debug("got unknown message type %s", str(msg['type']))
@@ -87,14 +87,14 @@ class TheDevice(Device):
     """
     def __init__(self,nodeId):
         Device.__init__(self,nodeId)
-        self.counter=0
+        self.counter = 0
 
     def refresh(self,fields):
         """
         the implementation of the refresh method
         """
         self._set_momentary_timestamp(self._get_timestamp())
-        self.counter+=self.counter
+        self.counter += self.counter
         self._add_field_momentary_data(self, "Temperature", self.counter)
 
 if __name__ == '__main__':

--- a/slixmpp/plugins/google/auth/stanza.py
+++ b/slixmpp/plugins/google/auth/stanza.py
@@ -15,8 +15,8 @@ class GoogleAuth(ElementBase):
     plugin_attrib = 'google'
     interfaces = {'client_uses_full_bind_result', 'service'}
 
-    discovery_attr= '{%s}client-uses-full-bind-result' % namespace
-    service_attr= '{%s}service' % namespace
+    discovery_attr = '{%s}client-uses-full-bind-result' % namespace
+    service_attr = '{%s}service' % namespace
 
     def setup(self, xml):
         """Don't create XML for the plugin."""

--- a/slixmpp/plugins/xep_0095/stream_initiation.py
+++ b/slixmpp/plugins/xep_0095/stream_initiation.py
@@ -39,7 +39,7 @@ class XEP_0095(BasePlugin):
         self._methods = {}
         self._methods_order = []
         self._pending_lock = threading.Lock()
-        self._pending= {}
+        self._pending = {}
 
         self.register_method(SOCKS5, 'xep_0065', 100)
         self.register_method(IBB, 'xep_0047', 50)

--- a/slixmpp/plugins/xep_0323/__init__.py
+++ b/slixmpp/plugins/xep_0323/__init__.py
@@ -15,4 +15,4 @@ from slixmpp.plugins.xep_0323 import stanza
 
 register_plugin(XEP_0323)
 
-xep_0323=XEP_0323
+xep_0323 = XEP_0323

--- a/slixmpp/plugins/xep_0325/__init__.py
+++ b/slixmpp/plugins/xep_0325/__init__.py
@@ -15,4 +15,4 @@ from slixmpp.plugins.xep_0325 import stanza
 
 register_plugin(XEP_0325)
 
-xep_0325=XEP_0325
+xep_0325 = XEP_0325

--- a/slixmpp/thirdparty/gnupg.py
+++ b/slixmpp/thirdparty/gnupg.py
@@ -771,9 +771,9 @@ class GPG(object):
         return result
 
     def delete_keys(self, fingerprints, secret=False):
-        which='key'
+        which = 'key'
         if secret:
-            which='secret-key'
+            which = 'secret-key'
         if _is_sequence(fingerprints):
             fingerprints = ' '.join(fingerprints)
         args = ['--batch --delete-%s "%s"' % (which, fingerprints)]
@@ -784,9 +784,9 @@ class GPG(object):
 
     def export_keys(self, keyids, secret=False):
         "export the indicated keys. 'keyid' is anything gpg accepts"
-        which=''
+        which = ''
         if secret:
-            which='-secret-key'
+            which = '-secret-key'
         if _is_sequence(keyids):
             keyids = ' '.join(['"%s"' % k for k in keyids])
         args = ["--armor --export%s %s" % (which, keyids)]
@@ -816,9 +816,9 @@ class GPG(object):
 
         """
 
-        which='keys'
+        which = 'keys'
         if secret:
-            which='secret-keys'
+            which = 'secret-keys'
         args = "--list-%s --fixed-list-mode --fingerprint --with-colons" % (which,)
         args = [args]
         p = self._open_subprocess(args)

--- a/tests/test_stanza_xep_0323.py
+++ b/tests/test_stanza_xep_0323.py
@@ -3,7 +3,7 @@
 from slixmpp.test import *
 import slixmpp.plugins.xep_0323 as xep_0323
 
-namespace='sn'
+namespace = 'sn'
 
 class TestSensorDataStanzas(SlixTest):
 
@@ -373,7 +373,7 @@ class TestSensorDataStanzas(SlixTest):
         """
         test of StringIds follow spec
         """
-        emptyStringIdXML='<message xmlns="jabber:client"><fields xmlns="urn:xmpp:iot:sensordata" /></message>'
+        emptyStringIdXML = '<message xmlns="jabber:client"><fields xmlns="urn:xmpp:iot:sensordata" /></message>'
 
         msg = self.Message()
         msg['fields']['stringIds'] = "Nisse"

--- a/tests/test_stanza_xep_0325.py
+++ b/tests/test_stanza_xep_0325.py
@@ -12,7 +12,7 @@
 from slixmpp.test import *
 import slixmpp.plugins.xep_0325 as xep_0325
 
-namespace='sn'
+namespace = 'sn'
 
 class TestControlStanzas(SlixTest):
 

--- a/tests/test_tostring.py
+++ b/tests/test_tostring.py
@@ -19,11 +19,11 @@ class TestToString(SlixTest):
         expected result.
         """
         if not expected:
-            expected=original
+            expected = original
         if isinstance(original, str):
             xml = ET.fromstring(original)
         else:
-            xml=original
+            xml = original
         result = tostring(xml, **kwargs)
         self.assertTrue(result == expected, "%s: %s" % (message, result))
 


### PR DESCRIPTION
PYTHON_E225: 'Fix extraneous whitespace around keywords.'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.