### PR TITLE
Fix port override in connect().

### DIFF
--- a/slixmpp/xmlstream/xmlstream.py
+++ b/slixmpp/xmlstream/xmlstream.py
@@ -302,7 +302,7 @@ class XMLStream(asyncio.BaseProtocol):
         record = await self.pick_dns_answer(self.default_domain)
         if record is not None:
             host, address, dns_port = record
-            port = dns_port if dns_port else self.address[1]
+            port = self.address[1] if self.address[1] else dns_port
             self.address = (address, port)
             self._service_name = host
         else:


### PR DESCRIPTION
At the moment, supplying a port to the `connect()` function is a no-op. It will always be replaced with the default port `5222` because `pick_dns_answer` always returns a default port.

It looks to me like the logic is reversed. If a port was explicitly supplied to `connect` then it should always be used. If not, fall back to whatever you get from the `pick_dns_answer`.

Feel free to close this an implement in another way if that's what you prefer.

How to repro:
```
xmpp = slixmpp.ClientXMPP(username, password)
xmpp.connect(address=("example.com", 9999))
xmpp.process()

DEBUG    Using selector: KqueueSelector
DEBUG    Loaded Plugin: RFC 6120: Stream Feature: STARTTLS
DEBUG    Loaded Plugin: RFC 6120: Stream Feature: Resource Binding
DEBUG    Loaded Plugin: RFC 3920: Stream Feature: Start Session
DEBUG    Loaded Plugin: RFC 6121: Stream Feature: Roster Versioning
DEBUG    Loaded Plugin: RFC 6121: Stream Feature: Subscription Pre-Approval
DEBUG    Loaded Plugin: RFC 6120: Stream Feature: SASL
DEBUG    Event triggered: connecting
DEBUG    DNS: Querying example.com for AAAA records.
DEBUG    DNS: Querying example.com for A records.
DEBUG    Connection failed: [Errno 61] Connect call failed ('2606:2800:220:1:248:1893:25c8:1946', 5222, 0, 0)
DEBUG    Event triggered: connection_failed
```

Note that the port fell back to the default 5222:
```
DEBUG    Connection failed: [Errno 61] Connect call failed ('2606:2800:220:1:248:1893:25c8:1946', 5222, 0, 0)
```