### PR TITLE
Fix deprecation warning regarding invalid escape sequences.

### DIFF
--- a/slixmpp/plugins/xep_0323/stanza/sensordata.py
+++ b/slixmpp/plugins/xep_0323/stanza/sensordata.py
@@ -516,7 +516,7 @@ class Field(ElementBase):
         :param value: string
         """
 
-        pattern = re.compile("^\d+([|]\w+([.]\w+)*([|][^,]*)?)?(,\d+([|]\w+([.]\w+)*([|][^,]*)?)?)*$")
+        pattern = re.compile(r"^\d+([|]\w+([.]\w+)*([|][^,]*)?)?(,\d+([|]\w+([.]\w+)*([|][^,]*)?)?)*$")
         if pattern.match(value) is not None:
             self.xml.stringIds = value
         else:

--- a/slixmpp/thirdparty/mini_dateutil.py
+++ b/slixmpp/thirdparty/mini_dateutil.py
@@ -160,7 +160,7 @@ except:
         return _fixed_offset_tzs[offsetmins]
 
 
-    _iso8601_parser = re.compile("""
+    _iso8601_parser = re.compile(r"""
         ^
         (?P<year> [0-9]{4})?(?P<ymdsep>-?)?
         (?P<month>[0-9]{2})?(?P=ymdsep)?


### PR DESCRIPTION
Deprecation warnings are raised for invalid escape sequences. Using raw strings will help in fixing the issue. Command to reproduce the issue on Python 3.7 and 3.8 by compiling all files.

```
$ find . -iname '*py' | grep -v example | xargs -I{} python3.8 -Wall -m py_compile {}
./slixmpp/plugins/xep_0323/stanza/sensordata.py:519: DeprecationWarning: invalid escape sequence \d
  pattern = re.compile("^\d+([|]\w+([.]\w+)*([|][^,]*)?)?(,\d+([|]\w+([.]\w+)*([|][^,]*)?)?)*$")
./slixmpp/thirdparty/mini_dateutil.py:163: DeprecationWarning: invalid escape sequence \s
  _iso8601_parser = re.compile("""
```