### PR TITLE
Force registration when using xep_0077 plugin

### DIFF
--- a/slixmpp/xmlstream/xmlstream.py
+++ b/slixmpp/xmlstream/xmlstream.py
@@ -1334,13 +1334,18 @@ class XMLStream(asyncio.BaseProtocol):
 
             passthrough = False
             if isinstance(data, Iq):
+                if "plugins" in vars(data) and isinstance(vars(data)["plugins"], dict):
+                    plugings_elt = vars(data)["plugins"]
+                    for keydict in plugings_elt:
+                        if isinstance(keydict, tuple) and "register" in ','.join([str(i) for i in keydict]):
+                            if "<class 'slixmpp.plugins.xep_0077.stanza.Register'>" in str(type(plugings_elt[keydict])):
+                                passthrough = True
                 if data.get_plugin('bind', check=True):
                     passthrough = True
                 elif data.get_plugin('session', check=True):
                     passthrough = True
             elif isinstance(data, Handshake):
                 passthrough = True
-
             if isinstance(data, (RootStanza, str)) and not passthrough:
                 self.__queued_stanzas.append((data, use_filters))
                 log.debug('NOT SENT: %s %s', type(data), data)


### PR DESCRIPTION
The registration is not applyed when we use xep_0077 plugin

################ Please use Gitlab instead of Github ###################################

Hello, thank you for contributing to slixmpp!

You’re about to open a pull request on github. However this github repository is not the official place for contributions on slixmpp.

Please open your merge request on https://lab.louiz.org/poezio/slixmpp/

You should be able to log in there with your github credentials, clone the slixmpp repository in your namespace, push your existing pull request into a new branch, and then open a merge request with one click, within 3 minutes.

This will help us review your contribution, avoid spreading things everywhere and it will even run the tests automatically with your changes.

Thank you.
