### PR TITLE
Compatibility with python 3.11+

### DIFF
--- a/slixmpp/xmlstream/xmlstream.py
+++ b/slixmpp/xmlstream/xmlstream.py
@@ -525,7 +525,7 @@ class XMLStream(asyncio.BaseProtocol):
             tasks: List[Awaitable] = [asyncio.sleep(timeout)]
             if not forever:
                 tasks.append(self.disconnected)
-            self.loop.run_until_complete(asyncio.wait(tasks))
+            self.loop.run_until_complete(asyncio.gather(*tasks))
 
     def init_parser(self) -> None:
         """init the XML parser. The parser must always be reset for each new


### PR DESCRIPTION
"Deprecated since version 3.8, will be removed in version 3.11: Passing coroutine objects to wait() directly is deprecated."

################ Please use Gitlab instead of Github ###################################

Hello, thank you for contributing to slixmpp!

You’re about to open a pull request on github. However this github repository is not the official place for contributions on slixmpp.

Please open your merge request on https://lab.louiz.org/poezio/slixmpp/

You should be able to log in there with your github credentials, clone the slixmpp repository in your namespace, push your existing pull request into a new branch, and then open a merge request with one click, within 3 minutes.

This will help us review your contribution, avoid spreading things everywhere and it will even run the tests automatically with your changes.

Thank you.
